### PR TITLE
[I18n] Add Rich Text Formatting support to Localize

### DIFF
--- a/packages/I18n/src/index.tsx
+++ b/packages/I18n/src/index.tsx
@@ -76,7 +76,7 @@ export default function mkI18n<
         ): ReactNode;
     };
 
-    type StronglyTypedFormattedMessageProps<V extends Record<string, any> = Record<string, ReactNode>> = {
+    type StronglyTypedFormattedMessageProps<V extends Record<string, any> = Record<string, ReactNode | FormatXMLElementFn<React.ReactNode, React.ReactNode>>> = {
         values?: V;
         tagName?: ElementType<any>;
         children?(...nodes: ReactNode[]): ReactNode;


### PR DESCRIPTION
Currently `<Localize/>` only allows `ReactNode` as a type of values inside prop `values`, which means [Rich Text Formatting](https://formatjs.io/docs/react-intl/components/#rich-text-formatting) is currently not supported.