### PR TITLE
Improve error/data values returned in commands without handlers in react-query-cqrs-client

### DIFF
--- a/packages/cqrs-clients/cqrs-client-base/src/index.ts
+++ b/packages/cqrs-clients/cqrs-client-base/src/index.ts
@@ -11,13 +11,17 @@ export type ValidationError<TErrorCodes extends Record<string, number>> = {
 }
 
 export type CommandResult<TErrorCodes extends Record<string, number>> =
-    | {
-          readonly WasSuccessful: false
-          readonly ValidationErrors: ValidationError<TErrorCodes>[]
-      }
-    | {
-          readonly WasSuccessful: true
-      }
+    | FailedCommandResult<TErrorCodes>
+    | SuccessfulCommandResult
+
+export type FailedCommandResult<TErrorCodes extends Record<string, number>> = {
+    readonly WasSuccessful: false
+    readonly ValidationErrors: ValidationError<TErrorCodes>[]
+}
+
+export type SuccessfulCommandResult = {
+    readonly WasSuccessful: true
+}
 
 export type ApiSuccess<TResult> = {
     readonly isSuccess: true


### PR DESCRIPTION
Breaking change if someone relied on result of  `mutateAsync` in commands without handlers, but its type was broken (didn't reflect that it would just return raw `AjaxResponse`/`AjaxError`) and no one noticed