### PR TITLE
fix: correct favicons paths for Vite deduplicated assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "prettier": ">=3.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "rollup": "^4.14.0",
+        "rollup": "^4.24.0",
         "sinon": "15.2.0",
         "stylelint": ">=16.0.0",
         "stylelint-config-recommended-scss": ">=14.0.0",
@@ -34637,7 +34637,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "vite": ">=4.0.0"
+        "vite": ">=6.0.0"
       }
     },
     "packages/vite-plugin-favicon/node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": ">=3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "rollup": "^4.14.0",
+    "rollup": "^4.24.0",
     "sinon": "15.2.0",
     "stylelint": ">=16.0.0",
     "stylelint-config-recommended-scss": ">=14.0.0",

--- a/packages/vite-plugin-favicon/package.json
+++ b/packages/vite-plugin-favicon/package.json
@@ -42,7 +42,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "vite": ">=4.0.0"
+    "vite": ">=6.0.0"
   },
   "dependencies": {
     "favicons": "^7.2.0",

--- a/packages/vite-plugin-favicon/src/lib/index.ts
+++ b/packages/vite-plugin-favicon/src/lib/index.ts
@@ -81,7 +81,17 @@ export function ViteFaviconsPlugin(options: FaviconsPluginArgs = {}): Plugin {
       if (!options.inject || !faviconResponse) return
 
       const tags: HtmlTagDescriptor[] = []
-      const assets = Object.values(ctx.bundle ?? {})
+      const assetFileName = Object.values(ctx.bundle ?? {}).reduce(
+        (acc, v) => {
+          if (v.type === "asset") {
+            for (const name of v.names) {
+              acc[name] = v.fileName
+            }
+          }
+          return acc
+        },
+        {} as Record<string, string>,
+      )
 
       for (const tag of faviconResponse.html) {
         const node = parseFragment(tag).childNodes[0]
@@ -91,7 +101,7 @@ export function ViteFaviconsPlugin(options: FaviconsPluginArgs = {}): Plugin {
             tag: node.tagName,
             attrs: node.attrs.reduce(
               (acc, v) => {
-                const name = assets.find(({ name }) => name === v.value.slice(1))?.fileName
+                const name = assetFileName[v.value.slice(1)]
 
                 acc[v.name] = name ? `/${name}` : v.value
 

--- a/packages/vite-plugin-favicon/src/lib/index.ts
+++ b/packages/vite-plugin-favicon/src/lib/index.ts
@@ -83,14 +83,13 @@ export function ViteFaviconsPlugin(options: FaviconsPluginArgs = {}): Plugin {
       const tags: HtmlTagDescriptor[] = []
       const assetFileName = Object.values(ctx.bundle ?? {}).reduce(
         (acc, v) => {
-          if (v.type === "asset") {
-            for (const name of v.names) {
-              acc[name] = v.fileName
-            }
+          if (v.type !== "asset") return acc
+          for (const name of v.names) {
+            acc[name] = v.fileName
           }
           return acc
         },
-        {} as Record<string, string>,
+        {} as Record<string, string | undefined>,
       )
 
       for (const tag of faviconResponse.html) {


### PR DESCRIPTION
Hi! First of all, thanks for the awesome tooling. 🙏

I noticed that `vite-plugin-favicon` may generate incorrect file paths during injection when Vite deduplicates an asset.

A simple repro is attached - after build, in `index.html`, the path for `apple-touch-icon-180x180.png` is incorrect.

This PR fixes the path resolution to ensure deduplicated assets are referenced correctly.
[vite-plugin-favicon-test.zip](https://github.com/user-attachments/files/25575361/vite-plugin-favicon-test.zip)
