### PR TITLE
fix(image-uploader): turn FileWithId into a union with all file state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # compiled output
 dist
 tmp
-/out-tsc
+out-tsc
 .publish
 *.tsbuildinfo
 

--- a/packages/image-uploader/src/lib/UploadImages/File.tsx
+++ b/packages/image-uploader/src/lib/UploadImages/File.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, ReactNode, useEffect, useState } from "react"
 import { getImagePreviewData } from "../_utils/getImagePreviewData"
-import { FileWithId, UploadFileItemChildProps } from "../types"
+import { UploadFileItemChildProps } from "../types"
 import { useUploadImagesContext } from "./Provider"
 
 /**
@@ -8,7 +8,7 @@ import { useUploadImagesContext } from "./Provider"
  */
 export type UploadImagesFileItemProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
   children: ((props: UploadFileItemChildProps) => ReactNode) | ReactNode
-  file: FileWithId
+  file: UploadFileItemChildProps["file"]
 }
 
 /**
@@ -42,19 +42,25 @@ export function UploadImagesFileItem({ children, file, ...props }: UploadImagesF
 
   const [previewData, setPreviewData] = useState<string>()
 
+  const url = "url" in file ? file.url : undefined
+
   useEffect(() => {
+    if (url) {
+      return
+    }
+
     const loadPreview = async () => {
       const preview = await getImagePreviewData(file.originalFile)
       setPreviewData(preview)
     }
 
     loadPreview()
-  }, [file.originalFile])
+  }, [url, file.originalFile])
 
   return (
     <div {...props}>
       {typeof children === "function"
-        ? children({ file, preview: previewData, remove: () => removeFile(file.id) })
+        ? children({ file, preview: url ?? previewData, remove: () => removeFile(file.id) })
         : children}
     </div>
   )

--- a/packages/image-uploader/src/lib/_utils/tryUploadWithUploadParams.ts
+++ b/packages/image-uploader/src/lib/_utils/tryUploadWithUploadParams.ts
@@ -23,7 +23,7 @@ import { FileWithId, UploadedFileWithId, UploadParams } from "../types"
  * ```
  */
 export async function tryUploadWithUploadParams(
-  image: FileWithId | UploadedFileWithId,
+  image: FileWithId,
   getUploadParams: (image: FileWithId) => Promise<UploadParams | null | undefined>,
 ): Promise<UploadedFileWithId> {
   if ("url" in image) {

--- a/packages/image-uploader/src/lib/types.ts
+++ b/packages/image-uploader/src/lib/types.ts
@@ -1,13 +1,15 @@
 export type { Accept, FileRejection } from "react-dropzone"
 
-export type FileWithId = {
+type BaseFileWithId = {
   originalFile: File
   id: string
 }
 
-export type UploadedFileWithId = FileWithId & {
+export type UploadedFileWithId = BaseFileWithId & {
   url: string
 }
+
+export type FileWithId = BaseFileWithId | UploadedFileWithId
 
 export type UploadParams = {
   uri: string


### PR DESCRIPTION
Currently `FileWithId` only exposes `file` and `id`, but consumer might want to access the url of the uploaded file. This PR `FileWithId` turns into union that represents all file states