### PR TITLE
fix(config): preserve literal `import.meta.env` in published dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # compiled output
 dist
 tmp
-/out-tsc
+out-tsc
 .publish
 *.tsbuildinfo
 

--- a/packages/config/__tests__/dist-consumer.spec.ts
+++ b/packages/config/__tests__/dist-consumer.spec.ts
@@ -1,0 +1,115 @@
+import { execSync } from "node:child_process"
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import * as path from "node:path"
+import { pathToFileURL } from "node:url"
+import { build } from "vite"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+// These tests validate the PUBLISHED artifact, not the source. The whole point
+// of `@leancodepl/config` is to defer `import.meta.env` resolution to the
+// consumer's Vite build, so the literal expression must survive into `dist` and
+// be textually replaced by a real consumer pipeline. The source-level specs in
+// `src/index.spec.ts` cannot catch this: they import from source and never
+// exercise the built output through Vite. Historical regressions this guards:
+//   - variant A (9.7.3-10.2.x): lib mode baked a frozen build-time snapshot into
+//     dist -> the consumer always sees `undefined`.
+//   - variant B (10.3.x-10.5.1): `const importMeta = import.meta` -> in the
+//     consumer this stays a bare `import.meta` (not textually replaced) whose
+//     `.env` is undefined -> `TypeError`.
+
+const testDir = import.meta.dirname
+const configPkgRoot = path.resolve(testDir, "..")
+const repoRoot = path.resolve(testDir, "../../..")
+const distEntry = path.join(configPkgRoot, "dist", "index.js")
+
+const expectedValue = "some-expected-value"
+
+let tmpDirs: string[] = []
+
+beforeAll(() => {
+  // `nx test config` builds dist first (project.json wires test -> dependsOn
+  // build). This fallback keeps the spec runnable via a bare `vitest` too.
+  if (!existsSync(distEntry)) {
+    execSync("npx nx build config", { cwd: repoRoot, stdio: "inherit" })
+  }
+}, 180_000)
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tmpDirs = []
+})
+
+describe("built dist (cheap static gate)", () => {
+  it("preserves a literal `import.meta.env` in the emitted ESM", () => {
+    const code = readFileSync(distEntry, "utf8")
+
+    // variant A leaves no literal `import.meta.env` (it is replaced by an
+    // inlined/frozen snapshot at library build time).
+    expect(code).toContain("import.meta.env")
+  })
+
+  it("does not stash `import.meta` into a local binding (variant B shape)", () => {
+    const code = readFileSync(distEntry, "utf8")
+
+    // `const importMeta = import.meta` (or any `= import.meta` not immediately
+    // followed by `.env`) is the variant B shape that breaks consumer-side
+    // textual replacement.
+    expect(code).not.toMatch(/=\s*import\.meta\b(?!\.env)/)
+  })
+})
+
+describe("built dist consumed through a real Vite build", () => {
+  it("resolves the consumer's env var at the consumer's build time", async () => {
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "config-dist-consumer-"))
+    tmpDirs.push(fixtureDir)
+
+    // A fixture that behaves like a downstream app depending on the built
+    // package. Importing the built `dist` by absolute path guarantees Vite
+    // bundles it (rather than externalising a bare specifier), so the
+    // consumer's pipeline is the thing that must textually replace
+    // `import.meta.env` -- exactly the real-world path.
+    writeFileSync(
+      path.join(fixtureDir, "package.json"),
+      JSON.stringify({ name: "config-dist-consumer-fixture", version: "0.0.0", type: "module" }),
+    )
+    writeFileSync(path.join(fixtureDir, ".env"), `VITE_FOO=${expectedValue}\n`)
+    writeFileSync(
+      path.join(fixtureDir, "entry.js"),
+      [
+        `import { mkGetInjectedConfig } from ${JSON.stringify(distEntry)}`,
+        "const { getInjectedConfig } = mkGetInjectedConfig()",
+        "export const result = getInjectedConfig('FOO')",
+        "",
+      ].join("\n"),
+    )
+
+    await build({
+      root: fixtureDir,
+      configFile: false,
+      logLevel: "silent",
+      build: {
+        outDir: path.join(fixtureDir, "out"),
+        emptyOutDir: true,
+        minify: false,
+        lib: {
+          entry: path.join(fixtureDir, "entry.js"),
+          formats: ["es"],
+          fileName: () => "consumer.js",
+        },
+        rollupOptions: { external: [] },
+      },
+    })
+
+    const outDir = path.join(fixtureDir, "out")
+    const outFile = readdirSync(outDir).find(f => f.endsWith(".js") || f.endsWith(".mjs"))
+    if (!outFile) throw new Error("consumer build produced no ESM output")
+
+    const mod = await import(pathToFileURL(path.join(outDir, outFile)).href)
+
+    // variant A -> undefined; variant B -> a broken lookup (undefined/TypeError).
+    expect(mod.result).toBe(expectedValue)
+  }, 120_000)
+})

--- a/packages/config/__tests__/dist-consumer.spec.ts
+++ b/packages/config/__tests__/dist-consumer.spec.ts
@@ -1,40 +1,23 @@
 import { execSync } from "node:child_process"
-import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import * as path from "node:path"
 import { pathToFileURL } from "node:url"
 import { build } from "vite"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
-// This test validates the PUBLISHED artifact, not the source. The whole point
-// of `@leancodepl/config` is to defer `import.meta.env` resolution to the
-// consumer's Vite build, so the literal expression must survive into `dist` and
-// be textually replaced by a real consumer pipeline. The source-level specs in
-// `src/index.spec.ts` cannot catch this: they import from source and never
-// exercise the built output through Vite. Historical regressions this guards:
-//   - variant A (9.7.3-10.2.x): lib mode baked a frozen build-time snapshot into
-//     dist -> the consumer always sees `undefined`.
-//   - variant B (10.3.x-10.5.1): `const importMeta = import.meta` -> in the
-//     consumer this stays a bare `import.meta` (not textually replaced) whose
-//     `.env` is undefined -> `TypeError`.
-
 const testDir = import.meta.dirname
-const configPkgRoot = path.resolve(testDir, "..")
-const repoRoot = path.resolve(testDir, "../../..")
-const distEntry = path.join(configPkgRoot, "dist", "index.js")
-
-// A committed fixture that behaves like a downstream app depending on the built
-// package (see `entry.js` for why it imports dist by relative path).
 const fixtureDir = path.join(testDir, "fixtures", "vite-consumer")
+const distEntry = path.resolve(testDir, "..", "dist", "index.js")
 const expectedValue = "some-expected-value"
 
 let tmpDirs: string[] = []
 
 beforeAll(() => {
-  // `nx test config` builds dist first (project.json wires test -> dependsOn
-  // build). This fallback keeps the spec runnable via a bare `vitest` too.
+  // `nx test config` builds dist first (test -> ^build). This keeps a bare
+  // `vitest` run working too.
   if (!existsSync(distEntry)) {
-    execSync("npx nx build config", { cwd: repoRoot, stdio: "inherit" })
+    execSync("npx nx build config", { cwd: path.resolve(testDir, "../../.."), stdio: "inherit" })
   }
 }, 180_000)
 
@@ -50,29 +33,15 @@ describe("built dist consumed through a real Vite build", () => {
     const outDir = mkdtempSync(path.join(tmpdir(), "config-dist-consumer-"))
     tmpDirs.push(outDir)
 
+    // Real consumer pipeline: builds the fixture (which imports the built
+    // `@leancodepl/config` by name) and only redirects output to a temp dir.
     await build({
-      root: fixtureDir,
-      configFile: false,
-      logLevel: "silent",
-      build: {
-        outDir,
-        emptyOutDir: true,
-        minify: false,
-        lib: {
-          entry: path.join(fixtureDir, "entry.js"),
-          formats: ["es"],
-          fileName: () => "consumer.js",
-        },
-        rollupOptions: { external: [] },
-      },
+      configFile: path.join(fixtureDir, "build-config.ts"),
+      build: { outDir },
     })
 
-    const outFile = readdirSync(outDir).find(f => f.endsWith(".js") || f.endsWith(".mjs"))
-    if (!outFile) throw new Error("consumer build produced no ESM output")
+    const mod = await import(pathToFileURL(path.join(outDir, "consumer.js")).href)
 
-    const mod = await import(pathToFileURL(path.join(outDir, outFile)).href)
-
-    // variant A -> undefined; variant B -> a broken lookup (undefined/TypeError).
     expect(mod.result).toBe(expectedValue)
   }, 120_000)
 })

--- a/packages/config/__tests__/dist-consumer.spec.ts
+++ b/packages/config/__tests__/dist-consumer.spec.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process"
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import * as path from "node:path"
 import { pathToFileURL } from "node:url"
@@ -40,25 +40,6 @@ afterAll(() => {
     rmSync(dir, { recursive: true, force: true })
   }
   tmpDirs = []
-})
-
-describe("built dist (cheap static gate)", () => {
-  it("preserves a literal `import.meta.env` in the emitted ESM", () => {
-    const code = readFileSync(distEntry, "utf8")
-
-    // variant A leaves no literal `import.meta.env` (it is replaced by an
-    // inlined/frozen snapshot at library build time).
-    expect(code).toContain("import.meta.env")
-  })
-
-  it("does not stash `import.meta` into a local binding (variant B shape)", () => {
-    const code = readFileSync(distEntry, "utf8")
-
-    // `const importMeta = import.meta` (or any `= import.meta` not immediately
-    // followed by `.env`) is the variant B shape that breaks consumer-side
-    // textual replacement.
-    expect(code).not.toMatch(/=\s*import\.meta\b(?!\.env)/)
-  })
 })
 
 describe("built dist consumed through a real Vite build", () => {

--- a/packages/config/__tests__/dist-consumer.spec.ts
+++ b/packages/config/__tests__/dist-consumer.spec.ts
@@ -1,12 +1,12 @@
 import { execSync } from "node:child_process"
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import * as path from "node:path"
 import { pathToFileURL } from "node:url"
 import { build } from "vite"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
-// These tests validate the PUBLISHED artifact, not the source. The whole point
+// This test validates the PUBLISHED artifact, not the source. The whole point
 // of `@leancodepl/config` is to defer `import.meta.env` resolution to the
 // consumer's Vite build, so the literal expression must survive into `dist` and
 // be textually replaced by a real consumer pipeline. The source-level specs in
@@ -23,6 +23,9 @@ const configPkgRoot = path.resolve(testDir, "..")
 const repoRoot = path.resolve(testDir, "../../..")
 const distEntry = path.join(configPkgRoot, "dist", "index.js")
 
+// A committed fixture that behaves like a downstream app depending on the built
+// package (see `entry.js` for why it imports dist by relative path).
+const fixtureDir = path.join(testDir, "fixtures", "vite-consumer")
 const expectedValue = "some-expected-value"
 
 let tmpDirs: string[] = []
@@ -44,35 +47,15 @@ afterAll(() => {
 
 describe("built dist consumed through a real Vite build", () => {
   it("resolves the consumer's env var at the consumer's build time", async () => {
-    const fixtureDir = mkdtempSync(path.join(tmpdir(), "config-dist-consumer-"))
-    tmpDirs.push(fixtureDir)
-
-    // A fixture that behaves like a downstream app depending on the built
-    // package. Importing the built `dist` by absolute path guarantees Vite
-    // bundles it (rather than externalising a bare specifier), so the
-    // consumer's pipeline is the thing that must textually replace
-    // `import.meta.env` -- exactly the real-world path.
-    writeFileSync(
-      path.join(fixtureDir, "package.json"),
-      JSON.stringify({ name: "config-dist-consumer-fixture", version: "0.0.0", type: "module" }),
-    )
-    writeFileSync(path.join(fixtureDir, ".env"), `VITE_FOO=${expectedValue}\n`)
-    writeFileSync(
-      path.join(fixtureDir, "entry.js"),
-      [
-        `import { mkGetInjectedConfig } from ${JSON.stringify(distEntry)}`,
-        "const { getInjectedConfig } = mkGetInjectedConfig()",
-        "export const result = getInjectedConfig('FOO')",
-        "",
-      ].join("\n"),
-    )
+    const outDir = mkdtempSync(path.join(tmpdir(), "config-dist-consumer-"))
+    tmpDirs.push(outDir)
 
     await build({
       root: fixtureDir,
       configFile: false,
       logLevel: "silent",
       build: {
-        outDir: path.join(fixtureDir, "out"),
+        outDir,
         emptyOutDir: true,
         minify: false,
         lib: {
@@ -84,7 +67,6 @@ describe("built dist consumed through a real Vite build", () => {
       },
     })
 
-    const outDir = path.join(fixtureDir, "out")
     const outFile = readdirSync(outDir).find(f => f.endsWith(".js") || f.endsWith(".mjs"))
     if (!outFile) throw new Error("consumer build produced no ESM output")
 

--- a/packages/config/__tests__/fixtures/vite-consumer/.env
+++ b/packages/config/__tests__/fixtures/vite-consumer/.env
@@ -1,0 +1,1 @@
+VITE_FOO=some-expected-value

--- a/packages/config/__tests__/fixtures/vite-consumer/build-config.ts
+++ b/packages/config/__tests__/fixtures/vite-consumer/build-config.ts
@@ -1,0 +1,20 @@
+import * as path from "node:path"
+import { defineConfig } from "vite"
+
+// Vite build config for the dist-consumer fixture. Deliberately NOT named
+// `vite.config.*`/`vitest.config.*`: the `@nx/vite`/`@nx/vitest` plugins infer
+// Nx targets from those globs, which would turn this fixture into a phantom
+// project. The spec loads this via `configFile` and only overrides `build.outDir`.
+export default defineConfig({
+  root: import.meta.dirname,
+  logLevel: "silent",
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    lib: {
+      entry: path.join(import.meta.dirname, "entry.js"),
+      formats: ["es"],
+      fileName: () => "consumer.js",
+    },
+  },
+})

--- a/packages/config/__tests__/fixtures/vite-consumer/entry.js
+++ b/packages/config/__tests__/fixtures/vite-consumer/entry.js
@@ -1,0 +1,9 @@
+// A downstream app that depends on the built `@leancodepl/config` package.
+// Importing the built `dist` by a relative path (rather than a bare specifier)
+// guarantees Vite bundles it, so the consumer's own pipeline is what must
+// textually replace `import.meta.env` -- exactly the real-world path.
+import { mkGetInjectedConfig } from "../../../dist"
+
+const { getInjectedConfig } = mkGetInjectedConfig()
+
+export const result = getInjectedConfig("FOO")

--- a/packages/config/__tests__/fixtures/vite-consumer/entry.js
+++ b/packages/config/__tests__/fixtures/vite-consumer/entry.js
@@ -1,8 +1,7 @@
-// A downstream app that depends on the built `@leancodepl/config` package.
-// Importing the built `dist` by a relative path (rather than a bare specifier)
-// guarantees Vite bundles it, so the consumer's own pipeline is what must
-// textually replace `import.meta.env` -- exactly the real-world path.
-import { mkGetInjectedConfig } from "../../../dist"
+// A downstream app that depends on the built `@leancodepl/config` by its public
+// package name. The fixture's own Vite build must bundle dist and textually
+// replace `import.meta.env` -- exactly the real-world consumer path.
+import { mkGetInjectedConfig } from "@leancodepl/config"
 
 const { getInjectedConfig } = mkGetInjectedConfig()
 

--- a/packages/config/__tests__/fixtures/vite-consumer/package.json
+++ b/packages/config/__tests__/fixtures/vite-consumer/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "config-dist-consumer-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/config/__tests__/fixtures/vite-consumer/package.json
+++ b/packages/config/__tests__/fixtures/vite-consumer/package.json
@@ -2,5 +2,11 @@
   "name": "config-dist-consumer-fixture",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@leancodepl/config": "*"
+  },
+  "devDependencies": {
+    "vite": "*"
+  }
 }

--- a/packages/config/project.json
+++ b/packages/config/project.json
@@ -1,0 +1,12 @@
+{
+  "name": "@leancodepl/config",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/config/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -20,8 +20,7 @@ declare global {
  * ```
  */
 export function mkGetInjectedConfig<TConfigKey extends string>() {
-  const importMeta = import.meta // this preserves the import.meta object in the bundle
   return {
-    getInjectedConfig: (key: TConfigKey) => importMeta.env[`VITE_${key}`] as string | undefined,
+    getInjectedConfig: (key: TConfigKey) => import.meta.env[`VITE_${key}`] as string | undefined,
   }
 }

--- a/packages/config/vite.config.mts
+++ b/packages/config/vite.config.mts
@@ -4,6 +4,7 @@ import { defineConfig, type Plugin } from "vite"
 import dts from "vite-plugin-dts"
 
 const importMetaEnvPlaceholder = "__preserved_import_meta_env__"
+const importMetaEnvCode = "import.meta.env"
 
 // This package's whole purpose is to defer `import.meta.env` lookups to the
 // consumer's Vite build. Vite resolves `import.meta.env` at build time (in lib
@@ -17,17 +18,15 @@ function preserveImportMetaEnv(): Plugin {
     enforce: "pre",
     apply: "build",
     transform(code) {
-      if (!code.includes("import.meta.env")) return
-      return { code: code.replaceAll("import.meta.env", importMetaEnvPlaceholder), map: null }
+      if (!code.includes(importMetaEnvCode)) return
+      return { code: code.replaceAll(importMetaEnvCode, importMetaEnvPlaceholder), map: null }
     },
     generateBundle(_options, bundle) {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== "chunk") continue
-        chunk.code = chunk.code.replaceAll(importMetaEnvPlaceholder, "import.meta.env")
-        if (!chunk.code.includes("import.meta.env")) {
-          this.error(
-            `${chunk.fileName} must contain a literal \`import.meta.env\` — consumers' Vite replaces it textually, so without it every getInjectedConfig call returns undefined`,
-          )
+        chunk.code = chunk.code.replaceAll(importMetaEnvPlaceholder, importMetaEnvCode)
+        if (!chunk.code.includes(importMetaEnvCode)) {
+          this.error(`${chunk.fileName} must contain a literal \`${importMetaEnvCode}\``)
         }
       }
     },

--- a/packages/config/vite.config.mts
+++ b/packages/config/vite.config.mts
@@ -1,12 +1,46 @@
 import * as path from "node:path"
 /// <reference types='vitest' />
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import dts from "vite-plugin-dts"
+
+const importMetaEnvPlaceholder = "__preserved_import_meta_env__"
+
+// This package's whole purpose is to defer `import.meta.env` lookups to the
+// consumer's Vite build. Vite resolves `import.meta.env` at build time (in lib
+// mode it inlines a frozen env snapshot, with no opt-out), and the consumer's
+// Vite detects the expression textually, so the literal `import.meta.env` must
+// survive into dist verbatim. Hide it behind a placeholder while the build
+// runs, restore it in the emitted chunks, and fail the build if it's missing.
+function preserveImportMetaEnv(): Plugin {
+  return {
+    name: "preserve-import-meta-env",
+    enforce: "pre",
+    apply: "build",
+    transform(code) {
+      if (!code.includes("import.meta.env")) return
+      return { code: code.replaceAll("import.meta.env", importMetaEnvPlaceholder), map: null }
+    },
+    generateBundle(_options, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== "chunk") continue
+        chunk.code = chunk.code.replaceAll(importMetaEnvPlaceholder, "import.meta.env")
+        if (!chunk.code.includes("import.meta.env")) {
+          this.error(
+            `${chunk.fileName} must contain a literal \`import.meta.env\` — consumers' Vite replaces it textually, so without it every getInjectedConfig call returns undefined`,
+          )
+        }
+      }
+    },
+  }
+}
 
 export default defineConfig(() => ({
   root: import.meta.dirname,
   cacheDir: "../../node_modules/.vite/packages/config",
-  plugins: [dts({ entryRoot: "src", tsconfigPath: path.join(import.meta.dirname, "tsconfig.lib.json") })],
+  plugins: [
+    dts({ entryRoot: "src", tsconfigPath: path.join(import.meta.dirname, "tsconfig.lib.json") }),
+    preserveImportMetaEnv(),
+  ],
   build: {
     outDir: "./dist",
     emptyOutDir: true,
@@ -18,6 +52,9 @@ export default defineConfig(() => ({
       entry: "src/index.ts",
       name: "@leancodepl/config",
       fileName: "index",
+      // No UMD build: `import.meta` is a syntax error in CJS, so the env access
+      // cannot be expressed there. The exports map only ever exposed the ESM file.
+      formats: ["es" as const],
     },
     rollupOptions: {
       external: [],


### PR DESCRIPTION
## Problem

Every `@leancodepl/config` version since **9.7.3** is broken: `getInjectedConfig` never returns a value in consumer apps. The bug shipped in two forms:

1. **9.7.3 – 10.2.x** — the package's own Vite lib-mode build statically replaced `import.meta.env` with a frozen build-time snapshot, baked into the published dist:
   ```js
   const t = { BASE_URL: "/", DEV: !1, MODE: "production", PROD: !0, SSR: !1 };
   // ...
   getInjectedConfig: (e) => t[`VITE_${e}`]  // always undefined
   ```
2. **10.3.x – 10.5.1** — the inlining was dodged with `const importMeta = import.meta`, but that breaks consumers differently:
   ```js
   const t = import.meta;
   // ...
   getInjectedConfig: (e) => t.env[`VITE_${e}`]  // TypeError: t.env is undefined
   ```

The root cause is the same in both: **consumers' Vite resolves `import.meta.env` purely textually**. The dev server injects the runtime env shim into a served module only when it sees the literal `import.meta.env` expression, and the build-time define replacement pattern-matches the same string. Once that literal is gone from our dist, no Vite version (verified on 7.1.7 and 8.1.3, esbuild and rolldown dep optimizers, dev and build) ever provides `env`, and in the browser native `import.meta` is just `{ url, resolve }`.

This is how it surfaced downstream (exampleapp, after bumping 9.5.1 → 10.5.1):

- dev: `TypeError: Cannot read properties of undefined (reading 'VITE_API_ENDPOINT')`
- with the 9.7.3-style dist: `API_ENDPOINT env variable has to be defined` (lookup silently returns `undefined`)

Last good published version is **9.7.2** (fts is safe on 9.6.3 for the same reason).

## Why not just configure the lib build?

There is no opt-out: Vite lib mode always resolves `import.meta.env` at build time, and a user `define: { "import.meta.env": "import.meta.env" }` is overwritten by Vite's internal env marker (verified on Vite 7 and 8 — both produce the frozen snapshot regardless). Building this package with a tool that leaves `import.meta.env` alone (esbuild/tsc) would also work, but stays off the monorepo's shared Vite/nx conventions.

## Fix

- Revert `const importMeta = import.meta` to a direct `import.meta.env[...]` access.
- Add a small `preserveImportMetaEnv` plugin to the package's vite config: it hides the expression behind a placeholder before `vite:define` runs and restores it in the emitted chunk.
- **Regression guard**: the same plugin fails the build if the emitted chunk doesn't contain the literal `import.meta.env`. Both historical variants of this bug would have been caught by it (verified by reintroducing the 10.3.x hack — the build fails).
- Drop the UMD output (`formats: ["es"]`, same as antd-table-hooks): `import.meta` is a syntax error in CJS so the access cannot be expressed there — the previous UMD build shimmed `import.meta` with only `url` and could never work — and the `exports` map only ever exposed the ESM file.

Built dist now:

```js
function t() {
  return {
    getInjectedConfig: (e) => import.meta.env[`VITE_${e}`]
  };
}
export {
  t as mkGetInjectedConfig
};
```

## Verification

- `nx build config`, `nx test config`, `nx lint config`, `nx typecheck config` all pass.
- The built dist was dropped into a consumer app and exercised in a real (headless Chromium) browser:
  - Vite 7.1.7 dev server → value from `.env.development` comes through.
  - Vite 8.1.3 production build + preview → build-time `VITE_*` env is baked in correctly, and the `getInjectedConfig("...")` call-site pattern survives in the bundle for nginx-base substitution.
- Negative test: reintroducing the `const importMeta = import.meta` hack makes the build fail with the guard's error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)