### PR TITLE
fix: make api-date brand classes and utils PrefixWith nameable in downstream declaration emit

### DIFF
--- a/packages/cqrs-clients/custom-types/date/api-date/src/index.ts
+++ b/packages/cqrs-clients/custom-types/date/api-date/src/index.ts
@@ -1,23 +1,22 @@
-class AD {
+class ApiDateOnly {
   declare private _: never
 }
-class ADT {
+class ApiDateTime {
   declare private _: never
 }
-class ATS {
-  declare private _: never
-}
-
-class AT {
+class ApiTimeSpan {
   declare private _: never
 }
 
-class ADO {
+class ApiTimeOnly {
   declare private _: never
 }
 
-export type ApiDateOnly = AD
-export type ApiDateTime = ADT
-export type ApiTimeSpan = ATS
-export type ApiTimeOnly = AT
-export type ApiDateTimeOffset = ADO
+class ApiDateTimeOffset {
+  declare private _: never
+}
+
+// Type-only so the brands stay un-instantiable, while remaining nameable in
+// downstream declaration emit (avoids TS4094 when a consumer's public type
+// inlines one of these brands).
+export type { ApiDateOnly, ApiDateTime, ApiDateTimeOffset, ApiTimeOnly, ApiTimeSpan }

--- a/packages/utils/src/lib/addPrefix.ts
+++ b/packages/utils/src/lib/addPrefix.ts
@@ -1,4 +1,6 @@
-type PrefixWith<T, TPrefix extends string> = { [K in keyof T as K extends string ? `${TPrefix}${K}` : never]: T[K] }
+export type PrefixWith<T, TPrefix extends string> = {
+  [K in keyof T as K extends string ? `${TPrefix}${K}` : never]: T[K]
+}
 
 /**
  * Adds a prefix to all keys in an object, creating a new object with prefixed keys.


### PR DESCRIPTION
## Problem

In consumers with declaration emit enabled (`composite` projects), exporting a value whose inferred type inlines `@leancodepl/api-date`'s brand classes fails with:

```
error TS4094: Property '_' of exported anonymous class type may not be private or protected.
```

The brand classes aren't exported (only aliases to them are), so once the alias information is lost inside a mapped-type expansion, TypeScript can't reference them by name. Typical trigger: `export const api = addPrefix(rawApi, "use")` + `export type Api = typeof api` over generated CQRS contracts with date fields. Hand-annotating the export works around it, but requires duplicating `addPrefix`'s return type, since `@leancodepl/utils` doesn't export that either.

## Fix

`api-date`: rename the brand classes to their public names and export them type-only, dropping the alias layer:

```ts
class ApiDateOnly {
  declare private _: never
}
// …

export type { ApiDateOnly, ApiDateTime, ApiDateTimeOffset, ApiTimeOnly, ApiTimeSpan }
```

The brands stay un-instantiable (type-only export forbids value use), and public type names, nominal semantics, and runtime output are unchanged — only the `.d.ts` shape changes.

`utils`: export the `PrefixWith` type from `addPrefix`, so consumers can write `type Api = PrefixWith<RawApi, "use">` instead of duplicating the mapped type.

Verified against a real failing app: with the new `.d.ts` shapes, declaration emit passes for both the `typeof api` form and the `PrefixWith`-annotated form. `nx affected -t build,test,typecheck` passes for all 13 affected projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)