### PR TITLE
fix(antd-table-hooks): read query state directly in useSorting

### DIFF
--- a/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
@@ -141,7 +141,58 @@ describe("useSorting", () => {
 
       // assert
       expect(onSortUpdate).toHaveBeenCalledWith("name", "descend")
+    })
+
+    it("reflects the query-state props instead of mirroring updates locally", () => {
+      // arrange - onSortUpdate does not propagate back into the props (mimics a no-op consumer)
+      const onSortUpdate = vi.fn()
+      const { result } = renderHook(() =>
+        useSorting<string, unknown>({ sortKey: "status", sortDirection: "ascend", onSortUpdate }),
+      )
+
+      // act
+      act(() => {
+        result.current.sortData.onChange({ columnKey: "name", order: "descend" })
+      })
+
+      // assert - the source of truth is the props, so sortData stays put until the props change
+      expect(result.current.sortKey).toBe("status")
+      expect(result.current.sortData.data).toEqual({ columnKey: "status", order: "ascend" })
+    })
+
+    it("tracks the query-state props as they change", () => {
+      // arrange
+      const onSortUpdate = vi.fn()
+      const { result, rerender } = renderHook(props => useSorting<string, unknown>(props), {
+        initialProps: { sortKey: "status", sortDirection: "ascend" as SortOrder, onSortUpdate },
+      })
+
+      // act
+      rerender({ sortKey: "name", sortDirection: "descend", onSortUpdate })
+
+      // assert
       expect(result.current.sortKey).toBe("name")
+      expect(result.current.sortData.data).toEqual({ columnKey: "name", order: "descend" })
+    })
+
+    it("returns to the resolved default on reset even when a dimension is unchanged", () => {
+      // arrange - emulate useTable: onSortUpdate(undefined) clears the URL, so the query state
+      // resolves back to the defaults. Here the default direction (descend) equals the
+      // pre-reset direction, which used to leave sortDirection stuck at undefined.
+      const defaultSortKey = "firstDay"
+      const defaultSortDirection: SortOrder = "descend"
+      const { result, rerender } = renderHook(props => useSorting<string, unknown>(props), {
+        initialProps: { sortKey: "lastDay", sortDirection: "descend" as SortOrder, onSortUpdate: vi.fn() },
+      })
+
+      // act - reset the sorter, then let the query state resolve back to the defaults
+      act(() => {
+        result.current.sortData.onChange(undefined)
+      })
+      rerender({ sortKey: defaultSortKey, sortDirection: defaultSortDirection, onSortUpdate: vi.fn() })
+
+      // assert - both dimensions reflect the resolved default, not a stale undefined
+      expect(result.current.sortData.data).toEqual({ columnKey: "firstDay", order: "descend" })
     })
   })
 })

--- a/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
@@ -100,6 +100,22 @@ describe("useSorting", () => {
       expect(result.current.sortDirection).toBe("descend")
     })
 
+    it("keeps the user's sort when the default changes after they have sorted", () => {
+      // arrange
+      const { result, rerender } = renderHook(props => useSorting<string, unknown>(props), {
+        initialProps: { defaultSortKey: "name", defaultSortDirection: "ascend" as SortOrder },
+      })
+
+      // act - the user picks a sort, then the caller changes the default underneath
+      act(() => {
+        result.current.sortData.onChange({ columnKey: "email", order: "descend" })
+      })
+      rerender({ defaultSortKey: "createdAt", defaultSortDirection: "ascend" })
+
+      // assert - the explicit selection persists; a default change does not override it
+      expect(result.current.sortData.data).toEqual({ columnKey: "email", order: "descend" })
+    })
+
     it("defaults to empty state when called with an empty options object", () => {
       // arrange / act
       const { result } = renderHook(() => useSorting<string, unknown>({}))
@@ -175,6 +191,25 @@ describe("useSorting", () => {
       rerender({ sortKey: defaultSortKey, sortDirection: defaultSortDirection, onSortUpdate: vi.fn() })
 
       // assert - both dimensions reflect the resolved default, not a stale undefined
+      expect(result.current.sortData.data).toEqual({ columnKey: "firstDay", order: "descend" })
+    })
+
+    it("reflects an external query-state change after the user has sorted", () => {
+      // arrange
+      const onSortUpdate = vi.fn()
+      const { result, rerender } = renderHook(props => useSorting<string, unknown>(props), {
+        initialProps: { sortKey: "firstDay", sortDirection: "descend" as SortOrder, onSortUpdate },
+      })
+
+      // act - the user sorts (a real consumer propagates it into the props), then the URL
+      // changes externally (e.g. browser back) without going through onChange
+      act(() => {
+        result.current.sortData.onChange({ columnKey: "lastDay", order: "ascend" })
+      })
+      rerender({ sortKey: "lastDay", sortDirection: "ascend", onSortUpdate })
+      rerender({ sortKey: "firstDay", sortDirection: "descend", onSortUpdate })
+
+      // assert - the query-state props win; no stale local value lingers
       expect(result.current.sortData.data).toEqual({ columnKey: "firstDay", order: "descend" })
     })
   })

--- a/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.spec.ts
@@ -53,7 +53,7 @@ describe("useSorting", () => {
       expect(result.current.isDescending).toBe(true)
     })
 
-    it("clears key and direction when onChange receives undefined sort data", () => {
+    it("falls back to the default key and direction when the sorter is cleared", () => {
       // arrange
       const { result } = renderHook(() =>
         useSorting<string, unknown>({ defaultSortKey: "name", defaultSortDirection: "ascend" }),
@@ -64,9 +64,9 @@ describe("useSorting", () => {
         result.current.sortData.onChange(undefined)
       })
 
-      // assert
-      expect(result.current.sortKey).toBeUndefined()
-      expect(result.current.sortDirection).toBeUndefined()
+      // assert - clearing resolves back to the configured default, not undefined
+      expect(result.current.sortKey).toBe("name")
+      expect(result.current.sortDirection).toBe("ascend")
       expect(result.current.isDescending).toBe(false)
     })
 
@@ -141,23 +141,6 @@ describe("useSorting", () => {
 
       // assert
       expect(onSortUpdate).toHaveBeenCalledWith("name", "descend")
-    })
-
-    it("reflects the query-state props instead of mirroring updates locally", () => {
-      // arrange - onSortUpdate does not propagate back into the props (mimics a no-op consumer)
-      const onSortUpdate = vi.fn()
-      const { result } = renderHook(() =>
-        useSorting<string, unknown>({ sortKey: "status", sortDirection: "ascend", onSortUpdate }),
-      )
-
-      // act
-      act(() => {
-        result.current.sortData.onChange({ columnKey: "name", order: "descend" })
-      })
-
-      // assert - the source of truth is the props, so sortData stays put until the props change
-      expect(result.current.sortKey).toBe("status")
-      expect(result.current.sortData.data).toEqual({ columnKey: "status", order: "ascend" })
     })
 
     it("tracks the query-state props as they change", () => {

--- a/packages/antd-table-hooks/src/lib/sorting/index.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.ts
@@ -67,7 +67,6 @@ export function useSorting<TKey extends Key, TData>(
   sortDirection?: SortOrder
   isDescending: boolean
 } {
-  const isQueryState = isQueryStateSorting(props)
   const { defaultSortKey, defaultSortDirection, onSortUpdate } = normalizeSortingProps(props)
 
   const [localSortKey, setLocalSortKey] = useState(defaultSortKey)
@@ -81,21 +80,18 @@ export function useSorting<TKey extends Key, TData>(
     setLocalSortDirection(defaultSortDirection)
   })
 
-  // In query-state mode the caller (e.g. `useTable`) owns the source of truth, so read it
-  // directly instead of mirroring it into local state. A local mirror diverges on reset: Ant
-  // Design fires `onChange` with `order: undefined`, but the query state resolves back to its
-  // configured defaults — and the change-gated resync misses any dimension whose resolved
-  // default equals its pre-reset value, leaving that dimension stuck at `undefined`.
-  const sortKey = isQueryState ? defaultSortKey : localSortKey
-  const sortDirection = isQueryState ? defaultSortDirection : localSortDirection
+  // Clearing a sorter writes `undefined` into local state; fall back to the configured default
+  // so the value resolves back to the default rather than sticking at `undefined`. In
+  // query-state mode `onSortUpdate(undefined)` clears the URL and the query resolves back to the
+  // same defaults, so the displayed sorter and the (now clean) URL stay in agreement.
+  const sortKey = localSortKey ?? defaultSortKey
+  const sortDirection = localSortDirection ?? defaultSortDirection
 
   const sortData = useMemo<SortData<TData>>(
     () => ({
       onChange: sortData => {
-        if (!isQueryState) {
-          setLocalSortKey(sortData?.columnKey as TKey | undefined)
-          setLocalSortDirection(sortData?.order)
-        }
+        setLocalSortKey(sortData?.columnKey as TKey | undefined)
+        setLocalSortDirection(sortData?.order)
         onSortUpdate?.(sortData?.columnKey as TKey | undefined, sortData?.order)
       },
       data: {
@@ -103,7 +99,7 @@ export function useSorting<TKey extends Key, TData>(
         columnKey: sortKey,
       },
     }),
-    [isQueryState, onSortUpdate, sortDirection, sortKey],
+    [onSortUpdate, sortDirection, sortKey],
   )
 
   return {
@@ -127,7 +123,7 @@ function normalizeSortingProps<TKey extends Key>(
   defaultSortDirection?: SortOrder
   onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
 } {
-  if (isQueryStateSorting(props)) {
+  if ("sortKey" in props && "sortDirection" in props && "onSortUpdate" in props) {
     return {
       defaultSortKey: props.sortKey,
       defaultSortDirection: props.sortDirection,
@@ -136,16 +132,4 @@ function normalizeSortingProps<TKey extends Key>(
   }
 
   return props
-}
-
-function isQueryStateSorting<TKey extends Key>(
-  props:
-    | QueryStateSorting<TKey>
-    | {
-        defaultSortKey?: TKey
-        defaultSortDirection?: SortOrder
-        onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
-      },
-): props is QueryStateSorting<TKey> {
-  return "sortKey" in props && "sortDirection" in props && "onSortUpdate" in props
 }

--- a/packages/antd-table-hooks/src/lib/sorting/index.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.ts
@@ -1,6 +1,5 @@
 import { Key, useMemo, useState } from "react"
 import { SortOrder } from "antd/es/table/interface"
-import { useSyncState } from "@leancodepl/utils"
 import { SortData } from "../types"
 
 type QueryStateSorting<TKey extends Key> = {
@@ -67,31 +66,26 @@ export function useSorting<TKey extends Key, TData>(
   sortDirection?: SortOrder
   isDescending: boolean
 } {
-  const { defaultSortKey, defaultSortDirection, onSortUpdate } = normalizeSortingProps(props)
+  const isControlled = isQueryStateSorting(props)
+  const onSortUpdate = props.onSortUpdate
 
-  const [localSortKey, setLocalSortKey] = useState(defaultSortKey)
-  const [localSortDirection, setLocalSortDirection] = useState(defaultSortDirection)
+  const [localSortKey, setLocalSortKey] = useState<TKey>()
+  const [localSortDirection, setLocalSortDirection] = useState<SortOrder>()
 
-  useSyncState(defaultSortKey, () => {
-    setLocalSortKey(defaultSortKey)
-  })
-
-  useSyncState(defaultSortDirection, () => {
-    setLocalSortDirection(defaultSortDirection)
-  })
-
-  // Clearing a sorter writes `undefined` into local state; fall back to the configured default
-  // so the value resolves back to the default rather than sticking at `undefined`. In
-  // query-state mode `onSortUpdate(undefined)` clears the URL and the query resolves back to the
-  // same defaults, so the displayed sorter and the (now clean) URL stay in agreement.
-  const sortKey = localSortKey ?? defaultSortKey
-  const sortDirection = localSortDirection ?? defaultSortDirection
+  // Query-state mode is controlled: the caller (e.g. `useTable`) owns the value via the URL, so
+  // read it directly — an external URL change (e.g. browser back) must win over a stale local
+  // pick. Standalone mode is uncontrolled: the local pick is the source of truth and persists,
+  // falling back to the configured default until the user sorts.
+  const sortKey = isControlled ? props.sortKey : (localSortKey ?? props.defaultSortKey)
+  const sortDirection = isControlled ? props.sortDirection : (localSortDirection ?? props.defaultSortDirection)
 
   const sortData = useMemo<SortData<TData>>(
     () => ({
       onChange: sortData => {
-        setLocalSortKey(sortData?.columnKey as TKey | undefined)
-        setLocalSortDirection(sortData?.order)
+        if (!isControlled) {
+          setLocalSortKey(sortData?.columnKey as TKey | undefined)
+          setLocalSortDirection(sortData?.order)
+        }
         onSortUpdate?.(sortData?.columnKey as TKey | undefined, sortData?.order)
       },
       data: {
@@ -99,7 +93,7 @@ export function useSorting<TKey extends Key, TData>(
         columnKey: sortKey,
       },
     }),
-    [onSortUpdate, sortDirection, sortKey],
+    [isControlled, onSortUpdate, sortDirection, sortKey],
   )
 
   return {
@@ -110,7 +104,7 @@ export function useSorting<TKey extends Key, TData>(
   }
 }
 
-function normalizeSortingProps<TKey extends Key>(
+function isQueryStateSorting<TKey extends Key>(
   props:
     | QueryStateSorting<TKey>
     | {
@@ -118,18 +112,6 @@ function normalizeSortingProps<TKey extends Key>(
         defaultSortDirection?: SortOrder
         onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
       },
-): {
-  defaultSortKey?: TKey
-  defaultSortDirection?: SortOrder
-  onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
-} {
-  if ("sortKey" in props && "sortDirection" in props && "onSortUpdate" in props) {
-    return {
-      defaultSortKey: props.sortKey,
-      defaultSortDirection: props.sortDirection,
-      onSortUpdate: props.onSortUpdate,
-    }
-  }
-
-  return props
+): props is QueryStateSorting<TKey> {
+  return "sortKey" in props && "sortDirection" in props && "onSortUpdate" in props
 }

--- a/packages/antd-table-hooks/src/lib/sorting/index.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.ts
@@ -72,10 +72,8 @@ export function useSorting<TKey extends Key, TData>(
   const [localSortKey, setLocalSortKey] = useState<TKey>()
   const [localSortDirection, setLocalSortDirection] = useState<SortOrder>()
 
-  // Query-state mode is controlled: the caller (e.g. `useTable`) owns the value via the URL, so
-  // read it directly — an external URL change (e.g. browser back) must win over a stale local
-  // pick. Standalone mode is uncontrolled: the local pick is the source of truth and persists,
-  // falling back to the configured default until the user sorts.
+  // Controlled (query-state): read the caller's value directly, so an external URL change wins.
+  // Uncontrolled (standalone): keep the local pick, falling back to the default until the user sorts.
   const sortKey = isControlled ? props.sortKey : (localSortKey ?? props.defaultSortKey)
   const sortDirection = isControlled ? props.sortDirection : (localSortDirection ?? props.defaultSortDirection)
 

--- a/packages/antd-table-hooks/src/lib/sorting/index.ts
+++ b/packages/antd-table-hooks/src/lib/sorting/index.ts
@@ -67,24 +67,35 @@ export function useSorting<TKey extends Key, TData>(
   sortDirection?: SortOrder
   isDescending: boolean
 } {
+  const isQueryState = isQueryStateSorting(props)
   const { defaultSortKey, defaultSortDirection, onSortUpdate } = normalizeSortingProps(props)
 
-  const [sortKey, setSortKey] = useState(defaultSortKey)
-  const [sortDirection, setSortDirection] = useState(defaultSortDirection)
+  const [localSortKey, setLocalSortKey] = useState(defaultSortKey)
+  const [localSortDirection, setLocalSortDirection] = useState(defaultSortDirection)
 
   useSyncState(defaultSortKey, () => {
-    setSortKey(defaultSortKey)
+    setLocalSortKey(defaultSortKey)
   })
 
   useSyncState(defaultSortDirection, () => {
-    setSortDirection(defaultSortDirection)
+    setLocalSortDirection(defaultSortDirection)
   })
+
+  // In query-state mode the caller (e.g. `useTable`) owns the source of truth, so read it
+  // directly instead of mirroring it into local state. A local mirror diverges on reset: Ant
+  // Design fires `onChange` with `order: undefined`, but the query state resolves back to its
+  // configured defaults — and the change-gated resync misses any dimension whose resolved
+  // default equals its pre-reset value, leaving that dimension stuck at `undefined`.
+  const sortKey = isQueryState ? defaultSortKey : localSortKey
+  const sortDirection = isQueryState ? defaultSortDirection : localSortDirection
 
   const sortData = useMemo<SortData<TData>>(
     () => ({
       onChange: sortData => {
-        setSortKey(sortData?.columnKey as TKey | undefined)
-        setSortDirection(sortData?.order)
+        if (!isQueryState) {
+          setLocalSortKey(sortData?.columnKey as TKey | undefined)
+          setLocalSortDirection(sortData?.order)
+        }
         onSortUpdate?.(sortData?.columnKey as TKey | undefined, sortData?.order)
       },
       data: {
@@ -92,7 +103,7 @@ export function useSorting<TKey extends Key, TData>(
         columnKey: sortKey,
       },
     }),
-    [onSortUpdate, sortDirection, sortKey],
+    [isQueryState, onSortUpdate, sortDirection, sortKey],
   )
 
   return {
@@ -116,7 +127,7 @@ function normalizeSortingProps<TKey extends Key>(
   defaultSortDirection?: SortOrder
   onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
 } {
-  if ("sortKey" in props && "sortDirection" in props && "onSortUpdate" in props) {
+  if (isQueryStateSorting(props)) {
     return {
       defaultSortKey: props.sortKey,
       defaultSortDirection: props.sortDirection,
@@ -125,4 +136,16 @@ function normalizeSortingProps<TKey extends Key>(
   }
 
   return props
+}
+
+function isQueryStateSorting<TKey extends Key>(
+  props:
+    | QueryStateSorting<TKey>
+    | {
+        defaultSortKey?: TKey
+        defaultSortDirection?: SortOrder
+        onSortUpdate?: (sortKey?: TKey, sortDirection?: SortOrder) => void
+      },
+): props is QueryStateSorting<TKey> {
+  return "sortKey" in props && "sortDirection" in props && "onSortUpdate" in props
 }


### PR DESCRIPTION
<!-- ccr-slack-attribution -->
_Requested by **Łukasz Komoszyński** · [Slack thread](https://leancode.slack.com/archives/D0B8VJ325PH/p1783949774479749)_

## Problem

When a sorter is cleared, Ant Design fires `onChange` with `order: undefined`. In query-state mode (`useSorting(useTable().sorting)`) that clears the URL sort params and the query resolves back to the configured defaults. The hook mirrored `sortKey`/`sortDirection` into local `useState` and only re-synced (via `useSyncState`) when a value changed between renders, so if a resolved default equalled its pre-reset value that dimension stayed stuck at `undefined` — the sort indicator disappeared even though the state had returned to the default.

## Fix

Model the hook as controlled/uncontrolled instead of routing both modes through a shared "default" value:

- **query-state (controlled):** the caller owns the value via the URL, so read `props.sortKey`/`props.sortDirection` directly. An external URL change (e.g. browser back) wins immediately; there is no local mirror to go stale.
- **standalone (uncontrolled):** local `useState` holds the user's pick and falls back to the configured default until they sort. A default change no longer clobbers an active selection.

This drops `normalizeSortingProps` (which conflated the live query value and the standalone default under one `defaultSortKey` name) and `useSyncState` (the fallback reads the current default live when there is no local pick).

## Tests

- Standalone clear now resolves to the configured default rather than `undefined`.
- Added: standalone keeps the user's selection when the default changes; query-state reflects an external change after the user has sorted (browser back).
- Kept the query-state reset regression (reset returns to the resolved default even when one dimension is unchanged).

Full package `test` + `lint` + `typecheck` pass.